### PR TITLE
ENG-1399: Traces for Python APM, Due to Flask v3.

### DIFF
--- a/nextjs/setup/my-app/package.json
+++ b/nextjs/setup/my-app/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@middleware.io/agent-apm-nextjs": "^1.1.0",
+    "@middleware.io/agent-apm-nextjs": "^1.2.0",
     "@opentelemetry/api": ">=1.3.0 <1.5.0",
     "next": "latest",
     "react": "^18.2.0",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
 middleware-apm==0.3.3
-flask==3.0.0
+flask==2.3.2
+# flask==3.0.0


### PR DESCRIPTION
Ticket: https://linear.app/middleware/issue/ENG-1399/python-apm-traces-are-not-coming-in-live
Flask v3 is not generating traces compatible with Opentelemetry. therefore, need to downgrade it to v2.
---
Github ref. link: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1975
Slack discussion: https://cloud-native.slack.com/archives/C01PD4HUVBL/p1696286832178269