### PR TITLE
ENG-3486 : Added instructions to run Python demo project in a serverless setup

### DIFF
--- a/python/django/README.md
+++ b/python/django/README.md
@@ -102,6 +102,13 @@ Now, you can go ahead to run your application, by using:
 ```python
 DJANGO_SETTINGS_MODULE='helloworld.settings' middleware-apm run python3 manage.py runserver
 ```
+
+If you are running this application in a serverless setup consider adding `MW_API_KEY` and `MW_TARGET` as mentioned in the command below :
+```python
+MW_API_KEY=********** MW_TARGET=https://*****.middleware.io:443 DJANGO_SETTINGS_MODULE='helloworld.settings' middleware-apm run python3 manage.py runserver
+```
+
+
 #### Note: If `middleware.ini` isn't in your project's root, set `MIDDLEWARE_CONFIG_FILE=./path/to/middleware.ini` along with the above run command.
 Then, you can open the URL http://127.0.0.1:8000/ in your web browser.
 

--- a/python/django/gunicorn/README.md
+++ b/python/django/gunicorn/README.md
@@ -21,4 +21,10 @@ Run the Application
 DJANGO_SETTINGS_MODULE='demo.settings' middleware-apm run gunicorn -c conf/gunicorn.conf.py --workers=4  --bind 0.0.0.0:8000 --timeout 120 demo.wsgi
 ```
 
+If you are running this application in a serverless setup consider adding `MW_API_KEY` and `MW_TARGET` as mentioned in the command below :
+```python
+MW_API_KEY=********** MW_TARGET=https://*****.middleware.io:443 DJANGO_SETTINGS_MODULE='demo.settings' middleware-apm run gunicorn -c conf/gunicorn.conf.py --workers=4  --bind 0.0.0.0:8000 --timeout 120 demo.wsgi
+```
+
+
 `Note:  --workers and --timeout are optional`

--- a/python/django/gunicorn/demo/demo/settings.py
+++ b/python/django/gunicorn/demo/demo/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-b+5n=gmp68i)mal_-dx8ophh@ga97m0d@4itxdj!zvxd%_py!n
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/python/django/gunicorn/demo/requirements.txt
+++ b/python/django/gunicorn/demo/requirements.txt
@@ -1,3 +1,3 @@
 Django==5.0.6
 gunicorn==22.0.0
-middleware-apm==0.6.0
+middleware-apm==1.0.0

--- a/python/django/helloworld/settings.py
+++ b/python/django/helloworld/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'matxp6k!wbkmdlk)97)ew2qr%&9nr=n#v_-+v#yel4^r&czf7q'
 DEBUG = True
 
 # A list of strings representing the host/domain names that this Django site can serve.
-ALLOWED_HOSTS = ['0.0.0.0']
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/python/django/requirements.txt
+++ b/python/django/requirements.txt
@@ -1,4 +1,4 @@
 # requirements.txt file
 Django==3.1.14
-middleware-apm==0.4.1
+middleware-apm==1.0.0
 

--- a/python/flask/README.md
+++ b/python/flask/README.md
@@ -66,10 +66,28 @@ collect_profiling = true
 ```
 #### Note: You need to replace <strong>\{YOUR-ACCESS-TOKEN\}</strong> with your APM's Access Token.
 
-## Run Your Application
+
+## Setup Virtual Environment
+```
+python -m venv newenv
+```
+```
+source newenv/bin/activate
+```
+```
+pip install -r requirements.txt
+```
+
+## Run Your Application 
+
+### Option 1 : With Host Agent
 To run your application, use the following command:
 ```shell
 middleware-apm run python app.py
+```
+### Option 2 : Serverless Setup
+```shell
+MW_API_KEY=********** MW_TARGET=https://*****.middleware.io:443 middleware-apm run python app.py
 ```
 #### Note: If `middleware.ini` isn't in your project's root, set `MIDDLEWARE_CONFIG_FILE=./path/to/middleware.ini` along with the above run command.
 

--- a/python/flask/requirements.txt
+++ b/python/flask/requirements.txt
@@ -1,3 +1,2 @@
-middleware-apm==0.6.0
+middleware-apm==1.0.0
 flask==2.3.2
-# flask==3.0.0


### PR DESCRIPTION
- Update Middleware Python APM package to latest `middleware-apm=1.0.0`
- Added instructions to run demo project in a serverless setup