### PR TITLE
feat(dbdemo): complex Postgres workload + trace correlation

### DIFF
--- a/nodejs/dbdemo/Dockerfile
+++ b/nodejs/dbdemo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.5-alpine
+FROM node:18-alpine
 ARG NPM_TOKEN
 # COPY .npmrc .npmrc
 COPY package.json package-lock.json ./

--- a/nodejs/dbdemo/app.js
+++ b/nodejs/dbdemo/app.js
@@ -1,5 +1,41 @@
 const tracker = require('@middleware.io/node-apm');
-tracker.track();
+
+// Start the Middleware agent.
+//  - disabledInstrumentations:"pg"  -> turn off the agent's built-in pg
+//    auto-instrumentation so we can register our own with the SQL commenter
+//    (the agent exposes no knob for addSqlCommenterCommentToQueries).
+//  - consoleLog:true                -> route console.log through the agent's
+//    OTel log pipeline, which stamps each record with the active span's
+//    trace_id/span_id (log <-> trace correlation).
+//
+// Note on the other two correlation needs: both are already automatic with the
+// Middleware agent, so no manual code here:
+//   * cross-service propagation -> the agent's global propagator + HTTP
+//     auto-instrumentation inject/extract trace context on every request.
+//   * logs <-> traces           -> the agent stamps trace_id/span_id on logs
+//     emitted within a span (tracker.info/error, console.error, winston/pino).
+//     consoleLog:true above just routes plain console.log through that pipeline.
+tracker.track({ disabledInstrumentations: "pg", consoleLog: true });
+
+// ---- Correlation: DB query <-> trace via SQL commenter -------------------
+// Register pg instrumentation with the W3C SQL commenter + enhanced reporting.
+// This patches `pg` (via require-in-the-middle) BEFORE the DB layer requires it
+// further down, so every statement is suffixed with a comment like
+//   /*traceparent='00-<trace-id>-<span-id>-01'*/
+// which shows up in pg_stat_activity.query and links the running query back to
+// its trace. Spans still flow to Middleware through the global TracerProvider
+// that the agent's NodeSDK installed in track() above.
+const { registerInstrumentations } = require('@opentelemetry/instrumentation');
+const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
+registerInstrumentations({
+    instrumentations: [
+        new PgInstrumentation({
+            addSqlCommenterCommentToQueries: true,
+            enhancedDatabaseReporting: true,
+            requireParentSpan: false,
+        }),
+    ],
+});
 
 const express = require('express');
 const app = express()
@@ -48,3 +84,4 @@ if (process.env.MW_AUTOGENERATE_TRACING_DATA) {
 }
 
 require("./app/routes/tutorial.routes.js")(app);
+require("./app/routes/dbload.routes.js")(app);

--- a/nodejs/dbdemo/app/dbload.js
+++ b/nodejs/dbdemo/app/dbload.js
@@ -29,6 +29,25 @@ const pool = new Pool({
 
 pool.on('error', (err) => console.error('[dbload] idle client error:', err.message));
 
+// pool.on('error') above only fires for *idle* clients sitting in the pool. A
+// client that is checked out (in use) emits 'error' on itself when its backend
+// dies unexpectedly — e.g. killed by idle_in_transaction_session_timeout, an
+// admin pg_terminate_backend, or a Postgres restart. With no listener that
+// becomes an unhandled 'error' event and crashes the whole process, so every
+// checked-out client gets a handler here.
+//
+// pg REUSES Client objects across checkouts, so attach the listener only once
+// per client — otherwise every pool.connect() stacks another listener on the
+// same object, leaking handlers and tripping MaxListenersExceededWarning.
+async function getClient() {
+    const client = await pool.connect();
+    if (!client._dbloadErrHandler) {
+        client._dbloadErrHandler = true;
+        client.on('error', (err) => console.error('[dbload] checked-out client error:', err.message));
+    }
+    return client;
+}
+
 const rnd = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 
@@ -88,7 +107,7 @@ function seedRows(n) {
 // 1) Heavy analytical read: window functions + percentile + group/join + sort,
 //    then a short pg_sleep so it lingers as an "active" query in pg_stat_activity.
 async function _complexAnalytics() {
-    const client = await pool.connect();
+    const client = await getClient();
     try {
         const t = Date.now();
         const res = await client.query(`
@@ -121,8 +140,8 @@ async function _complexAnalytics() {
 // 2) Lock contention: txn A holds a row lock while txn B waits on the same row.
 //    B shows up in pg_stat_activity with wait_event_type='Lock'.
 async function _lockingBlocking() {
-    const a = await pool.connect();
-    const b = await pool.connect();
+    const a = await getClient();
+    const b = await getClient();
     const id = rnd(1, ROW_TARGET);
     const holdMs = rnd(2000, 5000);
     try {
@@ -147,7 +166,7 @@ async function _lockingBlocking() {
 //    disk (wait_event_type='IO', BufFileRead/Write; temp bytes reported).
 //    Temp files are released automatically when the query ends.
 async function _ioWaitHeavySort() {
-    const client = await pool.connect();
+    const client = await getClient();
     try {
         const t = Date.now();
         await client.query("SET work_mem = '64kB'");
@@ -166,7 +185,7 @@ async function _ioWaitHeavySort() {
 
 // 4) CPU-bound sequential scan over the whole table (per-row md5).
 async function _seqScanHeavy() {
-    const client = await pool.connect();
+    const client = await getClient();
     try {
         const t = Date.now();
         const res = await client.query(`
@@ -183,7 +202,7 @@ async function _seqScanHeavy() {
 // 5) Idle-in-transaction: open a txn, run a query, sit idle, then commit.
 //    Shows as state='idle in transaction' in pg_stat_activity.
 async function _idleInTransaction() {
-    const client = await pool.connect();
+    const client = await getClient();
     const idleMs = rnd(3000, 6000);
     try {
         await client.query('BEGIN');
@@ -203,8 +222,8 @@ async function _idleInTransaction() {
 //    with 'deadlock detected' (40P01), producing an error span. Expected, so we
 //    swallow it and report which rows were involved.
 async function _deadlock() {
-    const a = await pool.connect();
-    const b = await pool.connect();
+    const a = await getClient();
+    const b = await getClient();
     let id1 = rnd(1, ROW_TARGET), id2 = rnd(1, ROW_TARGET);
     while (id2 === id1) id2 = rnd(1, ROW_TARGET);
     let deadlockHit = false;
@@ -239,7 +258,7 @@ async function _insertBatch() {
 
 // 8) Write churn — DELETE: remove a random batch of rows (full scan + sort).
 async function _deleteRandom() {
-    const client = await pool.connect();
+    const client = await getClient();
     const n = rnd(200, 1500);
     try {
         const t = Date.now();

--- a/nodejs/dbdemo/app/dbload.js
+++ b/nodejs/dbdemo/app/dbload.js
@@ -1,0 +1,349 @@
+'use strict';
+
+// Synthetic, "realistic" Postgres workload generator for the tutorials demo.
+//
+// Each scenario runs genuine SQL that surfaces in pg_stat_activity with a
+// recognisable state (active heavy query, Lock wait, IO/temp spill, idle in
+// transaction, deadlock, write churn). Because app.js enables the OTel SQL
+// commenter, every statement issued here carries a /*traceparent='...'*/
+// comment, so rows in pg_stat_activity link straight back to a trace.
+//
+// Storage safety: inserts grow the table, deletes churn it, and a background
+// maintenance loop caps the row count (MAX_ROWS) and periodically VACUUMs so
+// the database can never fill the disk on its own.
+
+const { Pool } = require('pg');
+
+// Dedicated pool with a distinct application_name so these queries are trivial
+// to find:  SELECT * FROM pg_stat_activity WHERE application_name='tutorials-dbload';
+const pool = new Pool({
+    host: process.env.POSTGRES_HOST || 'localhost',
+    port: parseInt(process.env.POSTGRES_PORT || '5432', 10),
+    user: process.env.POSTGRES_USER || 'postgres',
+    password: process.env.POSTGRES_PASSWORD || 'postgres',
+    database: process.env.POSTGRES_DB || 'todo',
+    max: 15,
+    idleTimeoutMillis: 30000,
+    application_name: 'tutorials-dbload',
+});
+
+pool.on('error', (err) => console.error('[dbload] idle client error:', err.message));
+
+const rnd = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
+
+const ROW_TARGET = 100000;   // baseline number of rows seeded at startup
+const MAX_ROWS   = 250000;   // hard ceiling enforced by the maintenance loop
+
+// ---------------------------------------------------------------------------
+// One-time schema + seed so scans / sorts / row locks have real data to chew on
+// ---------------------------------------------------------------------------
+let readyPromise = null;
+function ready() {
+    if (!readyPromise) {
+        readyPromise = ensureSchema().catch((e) => {
+            console.error('[dbload] ensureSchema failed:', e.message);
+            readyPromise = null; // allow a retry on the next call
+            throw e;
+        });
+    }
+    return readyPromise;
+}
+
+async function ensureSchema() {
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS dbload_items (
+            id          serial PRIMARY KEY,
+            category    text          NOT NULL,
+            amount      numeric(12,2) NOT NULL,
+            status      text          NOT NULL,
+            description text          NOT NULL,
+            created_at  timestamptz   NOT NULL DEFAULT now()
+        )`);
+    const { rows } = await pool.query('SELECT count(*)::int AS c FROM dbload_items');
+    const missing = ROW_TARGET - rows[0].c;
+    if (missing > 0) {
+        console.log(`[dbload] seeding dbload_items with ${missing} rows...`);
+        await seedRows(missing);
+        await pool.query('CREATE INDEX IF NOT EXISTS idx_dbload_items_cat ON dbload_items(category)');
+        await pool.query('ANALYZE dbload_items');
+    }
+    console.log('[dbload] schema ready');
+}
+
+function seedRows(n) {
+    return pool.query(`
+        INSERT INTO dbload_items (category, amount, status, description)
+        SELECT (ARRAY['alpha','beta','gamma','delta','omega'])[1 + (g % 5)],
+               round((random() * 1000)::numeric, 2),
+               (ARRAY['new','open','pending','closed','archived'])[1 + (g % 5)],
+               md5(g::text) || '-' || md5(random()::text)
+        FROM generate_series(1, $1) g`, [n]);
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+// 1) Heavy analytical read: window functions + percentile + group/join + sort,
+//    then a short pg_sleep so it lingers as an "active" query in pg_stat_activity.
+async function _complexAnalytics() {
+    const client = await pool.connect();
+    try {
+        const t = Date.now();
+        const res = await client.query(`
+            WITH ranked AS (
+                SELECT category, status, amount,
+                       row_number() OVER (PARTITION BY category ORDER BY amount DESC) AS rn,
+                       avg(amount)  OVER (PARTITION BY category)                       AS cat_avg
+                FROM dbload_items
+            ),
+            agg AS (
+                SELECT category, status, count(*) AS n, max(amount) AS max_amount,
+                       percentile_cont(0.95) WITHIN GROUP (ORDER BY amount) AS p95
+                FROM dbload_items
+                GROUP BY category, status
+            )
+            SELECT r.category, r.status, r.rn, r.cat_avg, a.n, a.max_amount, a.p95
+            FROM ranked r
+            JOIN agg a ON a.category = r.category AND a.status = r.status
+            WHERE r.rn <= 5
+            ORDER BY a.p95 DESC, r.category
+            LIMIT 50`);
+        const naps = (rnd(400, 1500) / 1000).toFixed(3);
+        await client.query('SELECT pg_sleep($1)', [naps]);
+        return { scenario: 'complexAnalytics', rows: res.rowCount, sleptSec: Number(naps), ms: Date.now() - t };
+    } finally {
+        client.release();
+    }
+}
+
+// 2) Lock contention: txn A holds a row lock while txn B waits on the same row.
+//    B shows up in pg_stat_activity with wait_event_type='Lock'.
+async function _lockingBlocking() {
+    const a = await pool.connect();
+    const b = await pool.connect();
+    const id = rnd(1, ROW_TARGET);
+    const holdMs = rnd(2000, 5000);
+    try {
+        await a.query('BEGIN');
+        await a.query('UPDATE dbload_items SET amount = amount + 1, status = $2 WHERE id = $1', [id, 'pending']);
+        // Fire B's update on the same row WITHOUT awaiting — it blocks until A commits.
+        const bUpdate = b.query('UPDATE dbload_items SET amount = amount + 2 WHERE id = $1', [id]);
+        await sleep(holdMs);            // <- B is blocked for this whole window
+        await a.query('COMMIT');
+        await bUpdate;                  // B unblocks and autocommits
+        return { scenario: 'lockingBlocking', id, blockedMs: holdMs };
+    } catch (e) {
+        try { await a.query('ROLLBACK'); } catch (_) {}
+        throw e;
+    } finally {
+        a.release();
+        b.release();
+    }
+}
+
+// 3) IO / temp-file pressure: a tiny work_mem forces a large sort to spill to
+//    disk (wait_event_type='IO', BufFileRead/Write; temp bytes reported).
+//    Temp files are released automatically when the query ends.
+async function _ioWaitHeavySort() {
+    const client = await pool.connect();
+    try {
+        const t = Date.now();
+        await client.query("SET work_mem = '64kB'");
+        const n = rnd(800000, 1800000);
+        const res = await client.query(`
+            SELECT g, md5(g::text) AS h
+            FROM generate_series(1, $1) g
+            ORDER BY md5(g::text)
+            LIMIT 100`, [n]);
+        await client.query('RESET work_mem');
+        return { scenario: 'ioWaitHeavySort', sorted: n, rows: res.rowCount, ms: Date.now() - t };
+    } finally {
+        client.release();
+    }
+}
+
+// 4) CPU-bound sequential scan over the whole table (per-row md5).
+async function _seqScanHeavy() {
+    const client = await pool.connect();
+    try {
+        const t = Date.now();
+        const res = await client.query(`
+            SELECT count(*) AS matches
+            FROM dbload_items
+            WHERE md5(description) < md5(category || amount::text)
+              AND description LIKE '%a%'`);
+        return { scenario: 'seqScanHeavy', matches: Number(res.rows[0].matches), ms: Date.now() - t };
+    } finally {
+        client.release();
+    }
+}
+
+// 5) Idle-in-transaction: open a txn, run a query, sit idle, then commit.
+//    Shows as state='idle in transaction' in pg_stat_activity.
+async function _idleInTransaction() {
+    const client = await pool.connect();
+    const idleMs = rnd(3000, 6000);
+    try {
+        await client.query('BEGIN');
+        await client.query('SELECT * FROM dbload_items WHERE id = $1', [rnd(1, ROW_TARGET)]);
+        await sleep(idleMs);
+        await client.query('COMMIT');
+        return { scenario: 'idleInTransaction', idleMs };
+    } catch (e) {
+        try { await client.query('ROLLBACK'); } catch (_) {}
+        throw e;
+    } finally {
+        client.release();
+    }
+}
+
+// 6) Deadlock: two txns lock two rows in opposite order; Postgres aborts one
+//    with 'deadlock detected' (40P01), producing an error span. Expected, so we
+//    swallow it and report which rows were involved.
+async function _deadlock() {
+    const a = await pool.connect();
+    const b = await pool.connect();
+    let id1 = rnd(1, ROW_TARGET), id2 = rnd(1, ROW_TARGET);
+    while (id2 === id1) id2 = rnd(1, ROW_TARGET);
+    let deadlockHit = false;
+    try {
+        await a.query('BEGIN');
+        await b.query('BEGIN');
+        await a.query('UPDATE dbload_items SET amount = amount + 1 WHERE id = $1', [id1]);
+        await b.query('UPDATE dbload_items SET amount = amount + 1 WHERE id = $1', [id2]);
+        // Cross-lock: each now waits for the row the other holds -> deadlock.
+        const ax = a.query('UPDATE dbload_items SET amount = amount + 1 WHERE id = $1', [id2]);
+        const bx = b.query('UPDATE dbload_items SET amount = amount + 1 WHERE id = $1', [id1]);
+        const results = await Promise.allSettled([ax, bx]);
+        deadlockHit = results.some((r) => r.status === 'rejected' && /deadlock/i.test(String(r.reason)));
+        try { await a.query('COMMIT'); } catch (_) {}
+        try { await b.query('COMMIT'); } catch (_) {}
+        return { scenario: 'deadlock', id1, id2, deadlockDetected: deadlockHit };
+    } finally {
+        try { await a.query('ROLLBACK'); } catch (_) {}
+        try { await b.query('ROLLBACK'); } catch (_) {}
+        a.release();
+        b.release();
+    }
+}
+
+// 7) Write churn — INSERT: append a batch of fresh rows.
+async function _insertBatch() {
+    const n = rnd(500, 2500);
+    const t = Date.now();
+    const res = await seedRows(n);
+    return { scenario: 'insertBatch', inserted: res.rowCount, ms: Date.now() - t };
+}
+
+// 8) Write churn — DELETE: remove a random batch of rows (full scan + sort).
+async function _deleteRandom() {
+    const client = await pool.connect();
+    const n = rnd(200, 1500);
+    try {
+        const t = Date.now();
+        const res = await client.query(`
+            DELETE FROM dbload_items
+            WHERE id IN (SELECT id FROM dbload_items ORDER BY random() LIMIT $1)`, [n]);
+        return { scenario: 'deleteRandom', deleted: res.rowCount, ms: Date.now() - t };
+    } finally {
+        client.release();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Automatic storage maintenance: keep the table under MAX_ROWS and reclaim
+// dead-tuple bloat with periodic VACUUM so the DB can't fill the disk.
+// ---------------------------------------------------------------------------
+async function enforceCap() {
+    await ready();
+    const { rows } = await pool.query('SELECT count(*)::int AS c FROM dbload_items');
+    const excess = rows[0].c - MAX_ROWS;
+    let deleted = 0;
+    if (excess > 0) {
+        const res = await pool.query(
+            `DELETE FROM dbload_items
+             WHERE id IN (SELECT id FROM dbload_items ORDER BY id ASC LIMIT $1)`, [excess]);
+        deleted = res.rowCount;
+        console.log(`[dbload] cap cleanup: deleted ${deleted} rows (was ${rows[0].c}, cap ${MAX_ROWS})`);
+    }
+    return { scenario: 'cleanup', rowsBefore: rows[0].c, deleted, cap: MAX_ROWS };
+}
+
+let maintenanceTicks = 0;
+async function maintenance() {
+    try {
+        await enforceCap();
+        maintenanceTicks++;
+        // VACUUM (ANALYZE) every ~5 minutes to reclaim dead tuples for reuse.
+        if (maintenanceTicks % 7 === 0) {
+            await pool.query('VACUUM (ANALYZE) dbload_items');
+            console.log('[dbload] VACUUM (ANALYZE) dbload_items done');
+        }
+    } catch (e) {
+        console.error('[dbload] maintenance error:', e.message);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency guard + weighted random picker
+// ---------------------------------------------------------------------------
+const MAX_INFLIGHT = 8;
+let inFlight = 0;
+
+function guarded(name, fn) {
+    return async function () {
+        if (inFlight >= MAX_INFLIGHT) {
+            return { scenario: name, skipped: true, reason: 'max in-flight reached', inFlight };
+        }
+        inFlight++;
+        try {
+            await ready();
+            return await fn();
+        } finally {
+            inFlight--;
+        }
+    };
+}
+
+const complexAnalytics  = guarded('complexAnalytics',  _complexAnalytics);
+const lockingBlocking   = guarded('lockingBlocking',   _lockingBlocking);
+const ioWaitHeavySort   = guarded('ioWaitHeavySort',   _ioWaitHeavySort);
+const seqScanHeavy      = guarded('seqScanHeavy',      _seqScanHeavy);
+const idleInTransaction = guarded('idleInTransaction', _idleInTransaction);
+const deadlock          = guarded('deadlock',          _deadlock);
+const insertBatch       = guarded('insertBatch',       _insertBatch);
+const deleteRandom      = guarded('deleteRandom',      _deleteRandom);
+const cleanup           = guarded('cleanup',           enforceCap);
+
+const SCENARIOS = [
+    { fn: complexAnalytics,  w: 22 },
+    { fn: lockingBlocking,   w: 16 },
+    { fn: ioWaitHeavySort,   w: 14 },
+    { fn: seqScanHeavy,      w: 12 },
+    { fn: idleInTransaction, w: 10 },
+    { fn: insertBatch,       w: 14 },  // inserts > deletes so the table stays populated;
+    { fn: deleteRandom,      w: 8  },  // the maintenance loop enforces the MAX_ROWS ceiling
+    { fn: deadlock,          w: 4  },
+];
+
+async function runRandom() {
+    const total = SCENARIOS.reduce((s, x) => s + x.w, 0);
+    let pick = Math.random() * total;
+    for (const s of SCENARIOS) {
+        pick -= s.w;
+        if (pick <= 0) return s.fn();
+    }
+    return SCENARIOS[0].fn();
+}
+
+// Build the schema in the background at startup (don't block module load) and
+// start the automatic storage-maintenance loop (every 45s).
+ready().catch(() => {});
+setInterval(maintenance, 45000).unref();
+
+module.exports = {
+    complexAnalytics, lockingBlocking, ioWaitHeavySort, seqScanHeavy,
+    idleInTransaction, deadlock, insertBatch, deleteRandom, cleanup, runRandom,
+};

--- a/nodejs/dbdemo/app/models/db.js
+++ b/nodejs/dbdemo/app/models/db.js
@@ -2,11 +2,16 @@ const { Pool } = require("pg");
 const dbConfig = require("../config/db.config.js");
 
 const pool = new Pool({
-  host: dbConfig.HOST,
-  user: dbConfig.USER,
-  password: dbConfig.PASSWORD,
-  database: dbConfig.DB
+  host: '1',
+  port: 5432,
+  user: 'postgres',
+  password: 'postgres',
+  database: 'todo'
 });
+
+// Without an 'error' listener, an unexpected drop on an idle pooled connection
+// becomes an unhandled 'error' event that crashes the whole process.
+pool.on("error", (err) => console.error("[db] idle client error:", err.message));
 
 module.exports = pool;
 

--- a/nodejs/dbdemo/app/routes/dbload.routes.js
+++ b/nodejs/dbdemo/app/routes/dbload.routes.js
@@ -1,0 +1,35 @@
+// Routes that drive the synthetic Postgres workload (see ../dbload.js).
+// Each handler runs inside the Express request span, so the DB spans it
+// produces are children of the request trace and carry a traceparent SQL
+// comment that shows up in pg_stat_activity.
+module.exports = app => {
+    const dbload = require("../dbload.js");
+    const router = require("express").Router();
+
+    const run = (fn) => (req, res) => {
+        fn()
+            .then((r) => {
+                // Logged inside the active request span -> with consoleLog:true the
+                // agent stamps this line with the same trace_id/span_id (log<->trace).
+                console.log(`[dbload] ${r && r.scenario}: ${JSON.stringify(r)}`);
+                res.status(200).send(r);
+            })
+            .catch((e) => {
+                console.error(`[dbload] error: ${String((e && e.message) || e)}`);
+                res.status(500).send({ error: String((e && e.message) || e) });
+            });
+    };
+
+    router.get("/complex",  run(dbload.complexAnalytics));
+    router.get("/blocking", run(dbload.lockingBlocking));
+    router.get("/iowait",   run(dbload.ioWaitHeavySort));
+    router.get("/seqscan",  run(dbload.seqScanHeavy));
+    router.get("/idletx",   run(dbload.idleInTransaction));
+    router.get("/deadlock", run(dbload.deadlock));
+    router.get("/insert",   run(dbload.insertBatch));
+    router.get("/delete",   run(dbload.deleteRandom));
+    router.get("/cleanup",  run(dbload.cleanup));
+    router.get("/random",   run(dbload.runRandom));
+
+    app.use('/api/dbload', router);
+};

--- a/nodejs/dbdemo/package.json
+++ b/nodejs/dbdemo/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@fluent-org/logger": "^1.0.9",
-    "@middleware.io/node-apm": "^1.2.5",
+    "@middleware.io/node-apm": "^2.4.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "fluent-logger": "^3.4.1",
@@ -19,5 +19,6 @@
     "winston": "^3.8.1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "diagnostics_channel": "^1.1.0"
 }

--- a/nodejs/dbdemo/tracingloop.js
+++ b/nodejs/dbdemo/tracingloop.js
@@ -46,4 +46,19 @@ if (process.env.MW_AUTOGENERATE_TRACING_DATA) {
         }
 
     },3000);
+
+    // Database workload generator: exercises complex / locking / IO-bound /
+    // write-churn queries so they surface in pg_stat_activity, each carrying a
+    // traceparent SQL comment. dbload.js caps row count + VACUUMs on its own, so
+    // this can run indefinitely without filling storage.
+    setInterval(() => {
+        let r = Math.random();
+        if (r < 0.55)      http.get('http://localhost:3002/api/dbload/random');
+        else if (r < 0.68) http.get('http://localhost:3002/api/dbload/complex');
+        else if (r < 0.78) http.get('http://localhost:3002/api/dbload/blocking');
+        else if (r < 0.86) http.get('http://localhost:3002/api/dbload/iowait');
+        else if (r < 0.92) http.get('http://localhost:3002/api/dbload/insert');
+        else if (r < 0.97) http.get('http://localhost:3002/api/dbload/seqscan');
+        else               http.get('http://localhost:3002/api/dbload/delete');
+    }, 4000);
 }


### PR DESCRIPTION
Add app/dbload.js with realistic query scenarios (heavy analytics, lock/blocking, IO/temp spill, seq scan, idle-in-transaction, deadlock, and insert/delete churn) exposed via /api/dbload/* and driven by the tracing loop, so they surface in pg_stat_activity.

Enable the OTel SQL commenter (PgInstrumentation
addSqlCommenterCommentToQueries) in app.js so every statement carries a traceparent comment for DB-query<->trace correlation, and route console.log through the agent log pipeline (consoleLog) for log<->trace correlation. A background loop caps row count and VACUUMs to keep storage bounded.